### PR TITLE
fix(model): corrige o removeRow quando o array.length é 0

### DIFF
--- a/model/writeCSV.ts
+++ b/model/writeCSV.ts
@@ -2,6 +2,7 @@ import { NewRow } from './interfaceData';
 import { readCSV } from './readCSV';
 
 import { createObjectCsvWriter } from 'csv-writer';
+import fs from 'fs/promises';
 
 
 export async function writeCSV(dbPath: string, row: NewRow[], append = true): Promise<void> {
@@ -22,5 +23,9 @@ export async function writeCSV(dbPath: string, row: NewRow[], append = true): Pr
 export async function removeRow(dbPath: string, nameExclude: string): Promise<void> {
     const rows = await readCSV(dbPath)
     const updatedRows = rows.filter(currentRow => currentRow.nome !== nameExclude)
+    if (updatedRows.length === 0) {
+        await fs.writeFile('db/estoque.csv', 'Nome,Peso,Valor,Quantidade\n')
+        return
+    }
     await writeCSV(dbPath, updatedRows, false);
 }


### PR DESCRIPTION
## Descrição

Na função model/removeRow quando retirava a úçtima linha ela criava uma linha sem valores que prejudicava outras funções

---

## Como testar

1. Crie estoque.csv no db/, exemplo de valores para o arquivo (não esqueça de criar uma nova linha no final):
```
Nome,Peso,Valor,Quantidade
aa,1,2,3

```
2. Crie um arquivo de teste temporário (test.ts) no root e cole:
```
import { readCSV } from "./model/readCSV";
import { writeCSV, removeRow } from "./model/writeCSV";
import { NewRow } from "./model/interfaceData";


const dbPath = 'db/estoque.csv'
const nameExclude = 'aa'


async function test() {
    let rows = await readCSV(dbPath)
    console.log(rows)

    await removeRow(dbPath, nameExclude)

    rows = await readCSV(dbPath)
    console.log(rows)
}


test()
```
4. Execute por exemplo com $npx ts-node test.ts
5. Confirme que a linha determinada pelo nameExclude foi excluída e caso seja a última, veja se não foi criado nenhuma linha sem valor
