### PR TITLE
fix: cria csv se não existir

### DIFF
--- a/model/readCSV.ts
+++ b/model/readCSV.ts
@@ -5,7 +5,7 @@ import { NewRow, dbPath } from './interfaceData';
 import { ensureFileExists } from './writeCSV';
 
 export async function readCSV(): Promise<NewRow[]> {
-    ensureFileExists(dbPath);
+    await ensureFileExists(dbPath);
     return new Promise((resolve, reject) => {
         const results: NewRow[] = [];
         fs.createReadStream(dbPath)

--- a/model/writeCSV.ts
+++ b/model/writeCSV.ts
@@ -3,18 +3,26 @@ import { dbPath } from './interfaceData';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
+
 export async function ensureFileExists(filePath: string): Promise<void> {
-    const absolutePath = path.resolve(filePath);
+    // const absolutePath = path.resolve(filePath);
     try {
-        await fs.access(absolutePath);
+        await fs.access(filePath);
         return;
     } catch {
-        throw new Error(`Arquivo não existe: ${absolutePath}`);
+        console.error("Arquivo csv não existe, criando ...")
+        try {
+            await fs.mkdir('db', { recursive: true });
+            const headers = 'Nome,Peso,Valor,Quantidade\n';
+            await fs.writeFile(filePath, headers, 'utf-8');
+        } catch (err) {
+            throw new Error(`Erro ao criar csv: ${err}`)
+        }
     }
 }
 
 export async function writeCSV(userRow: string[]): Promise<void> {
-    ensureFileExists(dbPath);
+    await ensureFileExists(dbPath);
     const formattedRow = userRow.join(',') + '\n';
 
     try {
@@ -27,7 +35,7 @@ export async function writeCSV(userRow: string[]): Promise<void> {
 
 export async function removeRow(lineIndex: number): Promise<void> {
     try {
-        ensureFileExists(dbPath);
+        await ensureFileExists(dbPath);
 
         const content = await fs.readFile(dbPath, 'utf-8');
         const lines = content.split('\n');


### PR DESCRIPTION
## Descrição

Corrige erro quando o /db/estoque.csv não está criado em funções do model

---

## Como testar

Execute com `$npx ts-node index.ts` sem criar /db/estoque.csv  e escolha uma função como a de criar um produto para criar o arquivo automaticamente.